### PR TITLE
Fix duplicate KEC button on variable products

### DIFF
--- a/assets/js/kec-cart.js
+++ b/assets/js/kec-cart.js
@@ -27,6 +27,11 @@ jQuery(function ($) {
         return;
       }
 
+      // Check if the button already exist.
+      if (null !== document.querySelector('#kec-pay-button').shadowRoot) {
+        return;
+      }
+
       window.Klarna.Payments.Buttons.init({
         client_key: client_key,
       }).load({

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fix
+
+* Fixed an issue where a new KEC button would be created on a variation product every time the customer selected a variation option. 
+
 ------------------
 
 ## [1.3.0] - 2024-01-31


### PR DESCRIPTION
Fixes an issue where the `onFoundVariation` was triggered every time the customer changes variant option. Since this function triggers a `load` every time, this would result in multiple duplicates of the KEC button.

- check if the button already exists before loading a new button.

https://app.clickup.com/t/86944n1zq
