### PR TITLE
Check if unavailable

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -85,6 +85,11 @@ class Settings {
 	 * @return bool
 	 */
 	public function is_enabled() {
+		$kp_unavailable_feature_ids = get_option( 'kp_unavailable_feature_ids', array() );
+		if ( in_array( 'kec_settings', $kp_unavailable_feature_ids ) ) {
+			return false;
+		}
+
 		return 'yes' === $this->options['kec_enabled'] ?? 'no';
 	}
 


### PR DESCRIPTION
Checks if feature is stored in the unavailable features option, added by the new API endpoint/available feature check for credentials in KP. If true, disable the feature.