### PR TITLE
Version 2.1.0

### DIFF
--- a/assets/js/kec-checkout.js
+++ b/assets/js/kec-checkout.js
@@ -25,9 +25,18 @@ jQuery(function ($) {
     init() {
       const { client_token } = kec_checkout_params;
 
-      Klarna.Payments.init({
-        client_token: client_token,
-      });
+      // Wait for the Klarna script to load.
+      const interval = setInterval(() => {
+        if (window.Klarna && window.Klarna.Payments && window.Klarna.Payments) {
+          clearInterval(interval);
+          Klarna.Payments.init({
+            client_token: client_token,
+          });
+        }
+      }, 100);
+
+      // Stop trying to initialize klarna after 2 seconds.
+      setTimeout(() => clearInterval(interval), 2000);
 
       // Add listener to load the iframe.
       $(document.body).on("updated_checkout", kec_checkout.loadIframe);

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+* Setting to select which flow to use for KEC when both one step checkout and two step flows are available and a AP key exists.
+
+### Fix
+* Fixed an issue where the one step checkout flow would not be prioritized when both flows were available.
 
 ------------------
 ## [2.0.0] - 2025-12-03

--- a/changelog.md
+++ b/changelog.md
@@ -6,13 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+------------------
+## [2.1.0] - 2026-01-16
 ### Added
 * Setting to select which flow to use for KEC when both one step checkout and two step flows are available and a AP key exists.
 
 ### Fix
 * Fixed an issue where the one step checkout flow would not be prioritized when both flows were available.
 
-------------------
 ## [2.0.0] - 2025-12-03
 ### Added
 * Implemented support for One step checkout flow for AP partners using Klarna Express Checkout.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "name": "krokedil/klarna-express-checkout",
     "description": "A Klarna Express Checkout solution for WooCommerce",
     "type": "library",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "require-dev": {
         "php-stubs/woocommerce-stubs": "^8.3",
         "10up/wp_mock": "^1.0",

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -84,18 +84,23 @@ class Assets {
 			return;
 		}
 
+		$two_step_available = PluginFeatures::is_available( Features::KEC_TWO_STEP );
+		$one_step_available = PluginFeatures::is_available( Features::KEC_ONE_STEP );
+
 		// If neither One step or Two step is available, return.
-		if ( ! PluginFeatures::is_available( Features::KEC_ONE_STEP ) && ! PluginFeatures::is_available( Features::KEC_TWO_STEP ) ) {
+		if ( ! $one_step_available && ! $two_step_available ) {
 			return;
 		}
 
+		$flow = $this->settings->get_kec_flow();
+
 		if ( is_cart() || is_product() ) {
-			if ( PluginFeatures::is_available( Features::KEC_ONE_STEP ) ) {
+			if ( $flow === 'one_step' && $one_step_available ) {
 				$this->enqueue_one_step_assets();
 			} else {
 				$this->enqueue_cart_assets();
 			}
-		} elseif ( is_checkout() && PluginFeatures::is_available( Features::KEC_TWO_STEP ) ) {
+		} elseif ( is_checkout() && $two_step_available ) {
 			$this->enqueue_checkout_assets();
 		}
 	}

--- a/src/KlarnaExpressCheckout.php
+++ b/src/KlarnaExpressCheckout.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
  * @package Krokedil\KlarnaExpressCheckout
  */
 class KlarnaExpressCheckout {
-	const VERSION = '2.0.0';
+	public const VERSION = '2.1.0';
 
 	/**
 	 * Reference to the Session class.

--- a/src/KlarnaExpressCheckout.php
+++ b/src/KlarnaExpressCheckout.php
@@ -83,7 +83,7 @@ class KlarnaExpressCheckout {
 		add_action( 'init', array( $this, 'maybe_unhook_kp_actions' ), 15 );
 		add_action( 'woocommerce_single_product_summary', array( $this, 'add_kec_button' ), 31 );
 		add_action( 'woocommerce_blocks_loaded', array( $this, 'setup_blocks_integration' ) );
-        OneStepCheckout::register_hooks();
+        OneStepCheckout::register_hooks( $this->settings->get_kec_flow() );
 
 		// Register the API controller for handling notifications in the Klarna API.
 		$this->register_api_controller();
@@ -186,8 +186,9 @@ class KlarnaExpressCheckout {
 	 * @return void
 	 */
 	public function setup_blocks_integration() {
-		// Only if One step is available.
-		if ( ! PluginFeatures::is_available( Features::KEC_ONE_STEP ) ) {
+		// Only if One step is the selected flow and available.
+		$flow = $this->settings->get_kec_flow();
+		if ( $flow !== 'one_step' || ! PluginFeatures::is_available( Features::KEC_ONE_STEP ) ) {
 			return;
 		}
 

--- a/src/OneStepCheckout.php
+++ b/src/OneStepCheckout.php
@@ -15,11 +15,13 @@ class OneStepCheckout {
 	/**
 	 * Register the hooks for the One Step Checkout flow that are needed.
 	 *
+	 * @param string $flow The selected KEC flow.
+	 *
 	 * @return void
 	 */
-	public static function register_hooks() {
-		// Only register the hooks if the feature is available.
-		if ( ! PluginFeatures::is_available( Features::KEC_ONE_STEP ) ) {
+	public static function register_hooks( $flow ) {
+		// Only register the hooks if the feature is available and the selected flow.
+		if ( $flow !== 'one_step' || ! PluginFeatures::is_available( Features::KEC_ONE_STEP ) ) {
 			return;
 		}
 		add_action( 'init', __CLASS__ . '::maybe_redirect_kec_one_step_checkout' );

--- a/tests/unit-tests/AssetsTest.php
+++ b/tests/unit-tests/AssetsTest.php
@@ -100,6 +100,7 @@ class AssetsTest extends TestCase {
 		$kpPluginFeatures = Mockery::mock( 'overload:Krokedil\Klarna\PluginFeatures' );
 		$kpPluginFeatures->shouldReceive('is_available')->with( 'klarna-express-checkout:1-step' )->andReturn( false );
 		$kpPluginFeatures->shouldReceive('is_available')->with( 'klarna-express-checkout:2-step' )->andReturn( true );
+		$kpPluginFeatures->shouldReceive('get_acquiring_partner_key')->with()->andReturn( false );
 		$assets->enqueue_assets();
 	}
 

--- a/tests/unit-tests/KlarnaExpressCheckoutTest.php
+++ b/tests/unit-tests/KlarnaExpressCheckoutTest.php
@@ -40,6 +40,7 @@ class KlarnaExpressCheckoutTest extends TestCase {
 		$kpPluginFeatures = Mockery::mock( 'overload:Krokedil\Klarna\PluginFeatures' );
 		$kpPluginFeatures->shouldReceive('is_available')->with( 'klarna-express-checkout:1-step' )->andReturn( false );
 		$kpPluginFeatures->shouldReceive('is_available')->with( 'klarna-express-checkout:2-step' )->andReturn( true );
+		$kpPluginFeatures->shouldReceive('get_acquiring_partner_key')->with()->andReturn( false );
 		$kpApiRegistry = Mockery::mock( 'overload:Krokedil\Klarna\Api\Registry' );
 		$kpApiRegistry->shouldReceive('register_controller')->with( Mockery::type( 'Krokedil\KlarnaExpressCheckout\Api\Controllers\Notifications' ) )->once();
 		$kpSession  = Mockery::mock( 'overload:KP_Session' );

--- a/tests/unit-tests/SettingsTest.php
+++ b/tests/unit-tests/SettingsTest.php
@@ -10,6 +10,10 @@ class SettingsTest extends TestCase {
 
 	public function setUp(): void {
 		parent::setUp();
+		$kpPluginFeatures = Mockery::mock( 'overload:Krokedil\Klarna\PluginFeatures' );
+		$kpPluginFeatures->shouldReceive('is_available')->with( 'klarna-express-checkout:1-step' )->andReturn( false );
+		$kpPluginFeatures->shouldReceive('is_available')->with( 'klarna-express-checkout:2-step' )->andReturn( true );
+		$kpPluginFeatures->shouldReceive('get_acquiring_partner_key')->with()->andReturn( false );
 		WP_Mock::userFunction( 'get_option' )->with( 'kec_webhook', array() )->andReturn( array() );
 		WP_Mock::userFunction( 'get_option' )->with( 'kec_signing_key', array() )->andReturn( array() );
 		WP_Mock::userFunction( 'get_option' )->with( 'kp_unavailable_feature_ids', array() )->andReturn( array() );


### PR DESCRIPTION
### Added
* Setting to select which flow to use for KEC when both one step checkout and two step flows are available and a AP key exists.

### Fix
* Fixed an issue where the one step checkout flow would not be prioritized when both flows were available.