### PR TITLE
Virtual product handling for the One-Step flow

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+* Improved structure of shipping data sent for digital products in the one step checkout flow.
+
+### Changed
 * Removed checks for acquiring partner keys for the one step flow, as it is now available to all users.
 
 ------------------

--- a/changelog.md
+++ b/changelog.md
@@ -8,8 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 * Improved structure of shipping data sent for digital products in the one step checkout flow.
-
-### Changed
 * Removed checks for acquiring partner keys for the one step flow, as it is now available to all users.
 
 ------------------

--- a/src/OneStepCheckout.php
+++ b/src/OneStepCheckout.php
@@ -184,7 +184,6 @@ class OneStepCheckout {
 					'amount'                  => 0,
 					'displayName'             => __( 'Digital delivery', 'klarna-express-checkout' ),
 					'description'             => __( 'Digital delivery', 'klarna-express-checkout' ),
-					'shippingType'            => 'DIGITAL_DOWNLOAD',
 				),
 			);
 		}

--- a/src/OneStepCheckout.php
+++ b/src/OneStepCheckout.php
@@ -175,21 +175,19 @@ class OneStepCheckout {
 
 		$shipping_needed = WC()->cart->needs_shipping();
 		// Klarna still expects shipping options for virtual carts, so provide a zero-cost fallback rate.
-		$packages = $shipping_needed ? WC()->shipping->get_packages() : array(
-			array(
-				'rates' => array(
-					new \WC_Shipping_Rate(
-						'id',
-						__( 'No shipping', 'klarna-express-checkout' ),
-						0,
-						array(),
-						'no_shipping'
-					),
+		if ( $shipping_needed ) {
+			$shipping_options = self::get_shipping_options( WC()->shipping->get_packages() );
+		} else {
+			$shipping_options = array(
+				array(
+					'shippingOptionReference' => 'digital-delivery',
+					'amount'                  => 0,
+					'displayName'             => __( 'Digital delivery', 'klarna-express-checkout' ),
+					'description'             => __( 'Digital delivery', 'klarna-express-checkout' ),
+					'shippingType'            => 'DIGITAL_DOWNLOAD',
 				),
-			),
-		);
-
-		$shipping_options = self::get_shipping_options( $packages );
+			);
+		}
 
 		$selected_shipping_option_reference = WC()->session->get( 'chosen_shipping_methods', array() );
 		$selected_shipping_option_reference = ( ! empty( $selected_shipping_option_reference ) ) ? $selected_shipping_option_reference[0] : '';

--- a/src/OneStepCheckout.php
+++ b/src/OneStepCheckout.php
@@ -174,10 +174,10 @@ class OneStepCheckout {
 		WC()->cart->calculate_totals();
 
 		$shipping_needed = WC()->cart->needs_shipping();
-		// Klarna still expects shipping options for virtual carts, so provide a zero-cost fallback rate.
 		if ( $shipping_needed ) {
 			$shipping_options = self::get_shipping_options( WC()->shipping->get_packages() );
 		} else {
+			// Klarna still expects shipping options for virtual carts, so provide a default one with free shipping and digital delivery.
 			$shipping_options = array(
 				array(
 					'shippingOptionReference' => 'digital-delivery',


### PR DESCRIPTION
**Important:** Adding `shippingType` of any type makes the flow break for me, seemingly regardless of how I structure the rest of the shipping data (using the exact example sent from the Klarna devs, etc).

Am I missing something crucial here, or should I keep the dialog going with Klarna?

**Update:** `shippingType` is not yet working as expected and should be removed for now, according to Klarna.

Improves the structure of shipping data sent for digital products in the one step checkout flow.