### PR TITLE
Version 2.1.4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ------------------
+## [2.1.4] - 2026-04-21
+### Security
+* Removed unused php-jwt package. The current version of the package has a security vulnerability that prevented package updates, but since we do not use it anywhere in the codebase, we can safely remove it from our dependencies.
+
 ## [2.1.3] - 2026-04-21
 ### Fix
 * Clarified the description for the `kec_flow` setting to indicate that the one step flow is now available to all users.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "name": "krokedil/klarna-express-checkout",
     "description": "A Klarna Express Checkout solution for WooCommerce",
     "type": "library",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "require-dev": {
         "php-stubs/woocommerce-stubs": "^8.3",
         "10up/wp_mock": "^1.0",
@@ -22,8 +22,7 @@
         }
     ],
     "require": {
-        "php": "~7.4 || ~8.0",
-        "firebase/php-jwt": "6.10.0"
+        "php": "~7.4 || ~8.0"
     },
     "archive": {
         "exclude": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,72 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "01b85b949eb027431f1ce185cb9c1343",
-    "packages": [
-        {
-            "name": "firebase/php-jwt",
-            "version": "v6.10.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "a49db6f0a5033aef5143295342f1c95521b075ff"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/a49db6f0a5033aef5143295342f1c95521b075ff",
-                "reference": "a49db6f0a5033aef5143295342f1c95521b075ff",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4||^8.0"
-            },
-            "require-dev": {
-                "guzzlehttp/guzzle": "^6.5||^7.4",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5",
-                "psr/cache": "^1.0||^2.0",
-                "psr/http-client": "^1.0",
-                "psr/http-factory": "^1.0"
-            },
-            "suggest": {
-                "ext-sodium": "Support EdDSA (Ed25519) signatures",
-                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Firebase\\JWT\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Neuman Vong",
-                    "email": "neuman+pear@twilio.com",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Anant Narayanan",
-                    "email": "anant@php.net",
-                    "role": "Developer"
-                }
-            ],
-            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
-            "homepage": "https://github.com/firebase/php-jwt",
-            "keywords": [
-                "jwt",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.10.0"
-            },
-            "time": "2023-12-01T16:26:39+00:00"
-        }
-    ],
+    "content-hash": "32693862b7a34ccc61738fcf7665365d",
+    "packages": [],
     "packages-dev": [
         {
             "name": "10up/wp_mock",
@@ -2619,15 +2555,15 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "~7.4 || ~8.0"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.4"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/KlarnaExpressCheckout.php
+++ b/src/KlarnaExpressCheckout.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
  * @package Krokedil\KlarnaExpressCheckout
  */
 class KlarnaExpressCheckout {
-	public const VERSION = '2.1.3';
+	public const VERSION = '2.1.4';
 
 	/**
 	 * Reference to the Session class.


### PR DESCRIPTION
### Security
* Removed unused php-jwt package. The current version of the package has a security vulnerability that prevented package updates, but since we do not use it anywhere in the codebase, we can safely remove it from our dependencies.