### PR TITLE
Ensure client id exists before registering module

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fix
+* Added a one step flow check to ensure a valid client ID is found before attempting to register module data.
 
 ------------------
 ## [2.1.4] - 2026-04-21

--- a/src/Assets.php
+++ b/src/Assets.php
@@ -226,6 +226,12 @@ class Assets {
 	 * @return void
 	 */
 	public function enqueue_one_step_assets() {
+		$client_id = $this->settings->get_credentials_secret();
+
+		if ( empty( $client_id ) ) {
+			return;
+		}
+
 		$amount = WC()->cart ? WC()->cart->get_total( 'raw' ) : 0;
 		// If this a product page?
 		if ( is_product() ) {
@@ -256,7 +262,7 @@ class Assets {
 					'method' => 'POST',
 				),
 			),
-			'client_id'    => $this->settings->get_credentials_secret(),
+			'client_id'    => $client_id,
 			'testmode'     => $this->settings->is_testmode(),
 			'theme'        => $this->settings->get_theme(),
 			'shape'        => $this->settings->get_shape(),


### PR DESCRIPTION
Added a one step flow check to ensure a valid client ID is found before attempting to register module data.