### PR TITLE
Fall back to the product ID when the product has no SKU.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fix
 * Disabled the KEC button on variable products until a variation is selected.
 
+### Fix
+* Fall back to the product ID for the `lineItemReference` when a product has no SKU, so the line item always passes Klarna's validation.
+
 ------------------
 ## [2.1.5] - 2026-05-11
 ### Fix

--- a/src/OneStepCheckout.php
+++ b/src/OneStepCheckout.php
@@ -294,9 +294,14 @@ class OneStepCheckout {
 			}
 
 			$image_url = wp_get_attachment_image_url( $product->get_image_id(), 'woocommerce_thumbnail' );
+
+			// Klarna requires lineItemReference to be 1-255 characters. Fall back to the product ID when the product has no SKU.
+			$sku                 = $product->get_sku();
+			$line_item_reference = '' !== $sku ? $sku : (string) $product->get_id();
+
 			$line_item = array(
 				'name'              => $product->get_name(),
-				'lineItemReference' => $product->get_sku(),
+				'lineItemReference' => $line_item_reference,
 				'quantity'          => $cart_item['quantity'],
 				'totalAmount'       => self::format_price( $cart_item['line_total'] + $cart_item['line_tax'] ), // Convert to cents.
 				'totalTaxAmount'    => self::format_price( $cart_item['line_tax'] ), // Convert to cents.


### PR DESCRIPTION
Ensures every cart line always has a, non-empty lineItemReference, preventing rejected initiate/shipping-change requests for products that don't define a SKU.